### PR TITLE
Update Getting started documentation - update start command

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ npm i -g yarn
 Start protofy in development mode (hot reload)
 
 ```sh
-yarn && yarn start-dev
+yarn && yarn dev
 ```
 
 ## Access the system


### PR DESCRIPTION
While trying to run the platform for the first time, i saw in the scripts that the starting running command should be yarn dev instead of yarn start-dev