### PR TITLE
Fix onEvent mask and wildcard handling error

### DIFF
--- a/apps/api/src/api.ts
+++ b/apps/api/src/api.ts
@@ -138,32 +138,30 @@ mqtt.on("message", (messageTopic, message) => {
         parsedMessage = JSON.parse(parsedMessage);
     } catch (err) { }
 
-    if(subscriptions[topic]) {
-        // Handle wildcard subscriptions
-        const validSubscriptions = Object.keys(subscriptions).filter(subscription => {
-            const subscriptionParts = subscription.split('/');
-            const topicParts = topic.split('/');
+    // Handle wildcard subscriptions
+    const validSubscriptions = Object.keys(subscriptions).filter(subscription => {
+        const subscriptionParts = subscription.split('/');
+        const topicParts = topic.split('/');
 
-            for (let i = 0; i < subscriptionParts.length; i++) {
-                if (subscriptionParts[i] === '#') {
-                    return true;
-                }
-
-                if (subscriptionParts[i] !== '+' && subscriptionParts[i] !== topicParts[i]) {
-                    return false;
-                }
+        for (let i = 0; i < subscriptionParts.length; i++) {
+            if (subscriptionParts[i] === '#') {
+                return true;
             }
-            return true;
-        });
 
-        validSubscriptions.forEach(subscription => {
-            
-            // console.log('SUUUUUUUUUUUUUUUUUUUUUB: ', subscriptions[subscription])
-            Object.keys(subscriptions[subscription]).forEach(subscriptionId => {
-                subscriptions[subscription][subscriptionId](parsedMessage, topic);
-            });
+            if (subscriptionParts[i] !== '+' && subscriptionParts[i] !== topicParts[i]) {
+                return false;
+            }
+        }
+        return true;
+    });
+
+    validSubscriptions.forEach(subscription => {
+        
+        // console.log('SUUUUUUUUUUUUUUUUUUUUUB: ', subscriptions[subscription])
+        Object.keys(subscriptions[subscription]).forEach(subscriptionId => {
+            subscriptions[subscription][subscriptionId](parsedMessage, topic);
         });
-    }
+    });
 });
 
 export default app

--- a/packages/protolib/bundles/events/api/index.ts
+++ b/packages/protolib/bundles/events/api/index.ts
@@ -4,16 +4,15 @@ import { generateEvent } from "../eventsLibrary"
 export const onEvent = (context, cb, path?, from?) => {
     context.topicSub('notifications/event/create/#', (async (msg: string, topic: string) => {
         try {
-            const message = JSON.parse(msg)
-            if (message) {
-                if (path && message['path'] != path) {
+            if (msg) {
+                if (path && msg['path'] != path) {
                     return
                 }
-                if (from && message['from'] != from) {
+                if (from && msg['from'] != from) {
                     return
                 }
             }
-            cb(message)
+            cb(msg)
         } catch (e) {
             console.error('Error parsing message from mqtt: ', e)
         }


### PR DESCRIPTION
Fix flows onEvent mask: Parsing from JSON to Object a Object not a string, this leads to an error parsing to Object and Object.

Fix MQTT topic subscription check: If we see how is handled mqtt subscription on `Protofy/apps/api/src/api.ts` there is an error if we use wildcards. On topicSub we add a value to subscriptions with let's say the key "test/#" (which is wildcard for all messages that came from test, something like test/*. Then on 

```ts
  
mqtt.on("message", (messageTopic, message) => {
    const topic = messageTopic.toString()
    let parsedMessage = message.toString()
    try {
        parsedMessage = JSON.parse(parsedMessage);
    } catch (err) { }

    if(subscriptions[topic]) {  <--------------- HERE
        // Handle wildcard subscriptions
        const validSubscriptions = Object.keys(subscriptions).filter(subscription => {
    
    ...
```

We check if we're subscribed to that topic. A topic like: 

`test/sample`

Will always fail even if we're subscribed with wildcard to `test/#` since on our subscriptions map we're subscribed to `test/#` not `test/sample`. 