### PR TITLE
Build y subida de artefacto .dmg comprimido para macOS (arm64) y Windows

### DIFF
--- a/.github/workflows/build-vento.yml
+++ b/.github/workflows/build-vento.yml
@@ -47,6 +47,12 @@ jobs:
       - name: Build macOS App
         run: yarn app-package
 
+      - name: Create ZIP from DMG
+        run: |
+          mkdir -p upload-artifact
+          cd ../dist
+          zip -r $GITHUB_WORKSPACE/upload-artifact/Vento-macOS-arm64.zip Vento-*-arm64.dmg
+
       - name: Upload to GitHub Release
         if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: softprops/action-gh-release@v2
@@ -54,7 +60,7 @@ jobs:
           tag_name: ${{ github.event.inputs.tag_name }}
           name: ${{ github.event.inputs.release_name }}
           prerelease: ${{ github.event.inputs.prerelease }}
-          files: ../dist/Vento-*-arm64.dmg
+          files: upload-artifact/Vento-macOS-arm64.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
📝 Descripción:
Este PR modifica el workflow de GitHub Actions para:

 - Construir la app de macOS para arquitectura arm64 y Windows usando electron-builder.

Comprimir el archivo .dmg generado en un archivo .zip para evitar el error de seguridad "La app está dañada y no se puede abrir" en macOS.

Subir los archivos generados como artefactos de release de GitHub.

📦 Esto permite a los usuarios descargar el .zip, descomprimirlo localmente y abrir el .dmg y instalarlo en MacOS como aplicación.

En MacOS: Actualmente existe el problema que se detecta como que la app tiene un error debido a que no esta firmado. Existe la necesidad de firmarlo, evitando el error de cuarentena.


Adjunto video y screenshoots de los archivos de MacOS y Windows que se suben en releases:
![image](https://github.com/user-attachments/assets/3fd3cd4b-cf95-402b-909a-73ba3a14d500)

Adjunto video de como se llega a instalar y a abrir la app en MacOS (bypasseando el problema de quarentena):

https://github.com/user-attachments/assets/92316391-0a4a-43c8-a157-3e7c8df30d6d


